### PR TITLE
Declare missing dependency on git

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -12,6 +12,7 @@
   <author>Stephan Brumme</author>
 
   <buildtool_depend>ament_cmake_auto</buildtool_depend>
+  <buildtool_depend>git</buildtool_depend>
 
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>ament_lint_common</test_depend>


### PR DESCRIPTION
This should resolve build issues for RHEL, where git is not implicitly included as a build dependency: https://build.ros2.org/job/Rbin_rhel_el864__hash_library_vendor__rhel_8_x86_64__binary/25/display/redirect

Thanks!